### PR TITLE
Updated ic_photo_camera.xml

### DIFF
--- a/pix/src/main/res/drawable/ic_photo_camera.xml
+++ b/pix/src/main/res/drawable/ic_photo_camera.xml
@@ -1,12 +1,16 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportHeight="490.0"
-    android:viewportWidth="490.0">
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M0,167.9v216.2c0,33 26.8,59.8 59.8,59.8h370.4c33,0 59.8,-26.8 59.8,-59.8v-216.2c0,-31.4 -25.5,-56.9 -56.9,-56.9h-79.6l-1.9,-8.3c-7.7,-33.3 -37,-56.5 -71.2,-56.5h-70.9c-34.1,0 -63.4,23.2 -71.2,56.5l-1.9,8.3H56.9C25.5,110.9 0,136.6 0,167.9zM146.2,135.4c5.7,0 10.6,-3.9 11.9,-9.5l4.1,-17.8c5.2,-22.1 24.6,-37.5 47.3,-37.5h70.9c22.7,0 42.1,15.4 47.3,37.5l4.1,17.8c1.3,5.5 6.2,9.5 11.9,9.5H433c17.9,0 32.4,14.5 32.4,32.4v216.2c0,19.5 -15.8,35.3 -35.3,35.3H59.8c-19.5,0 -35.3,-15.8 -35.3,-35.3v-216.2c0,-17.9 14.5,-32.4 32.4,-32.4H146.2z" />
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M245,381c56.7,0 102.9,-46.2 102.9,-102.9s-46.2,-102.9 -102.9,-102.9s-102.9,46.1 -102.9,102.9S188.3,381 245,381zM245,199.6c43.2,0 78.4,35.2 78.4,78.4s-35.2,78.4 -78.4,78.4s-78.4,-35.2 -78.4,-78.4S201.8,199.6 245,199.6z" />
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,5h-3.17L15,3H9L7.17,5H4C2.9,5 2,5.9 2,7v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V7C22,5.9 21.1,5 20,5zM20,19H4V7h3.17h0.88l0.59,-0.65L9.88,5h4.24l1.24,1.35L15.95,7h0.88H20V19z"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,17c-2.21,0 -4,-1.79 -4,-4h2l-2.5,-2.5L5,13h2c0,2.76 2.24,5 5,5c0.86,0 1.65,-0.24 2.36,-0.62l-0.74,-0.74C13.13,16.87 12.58,17 12,17z"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8c-0.86,0 -1.65,0.24 -2.36,0.62l0.74,0.73C10.87,9.13 11.42,9 12,9c2.21,0 4,1.79 4,4h-2l2.5,2.5L19,13h-2C17,10.24 14.76,8 12,8z"/>
 </vector>


### PR DESCRIPTION
Added new and modern icon (currently used by WhatsApp for indicating camera flipping from the rear camera to front camera) instead of the one. The icon used is according to the Material Guidelines.