### PR TITLE
drop jetifier

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,13 +37,14 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0'
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation project(':pix')
     implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha05'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "androidx.annotation:annotation:1.1.0"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.0'
 
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,6 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 android.debug.obsoleteApi=true

--- a/pix/build.gradle
+++ b/pix/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
+    implementation "androidx.annotation:annotation:1.1.0"
 }
 
 apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/master/android-release-aar.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':pix'
+include ':app', ':pix'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':pix'
+include ':pix'


### PR DESCRIPTION
Hi! Thank you for making PixImagePicker! we are using this in our project.

The reason for this pull request is to drop jetifier. We're experimenting to reduce the build time of our projects and we found out by dropping jetifier we can reduce a significant amount of build time. thank you!

also I check the project and there's no issue I also run the app it's fine.