### PR TITLE
Fix exception when setting up camera on view not attached to window

### DIFF
--- a/pix/src/main/java/io/ak1/pix/helpers/CameraXManager.kt
+++ b/pix/src/main/java/io/ak1/pix/helpers/CameraXManager.kt
@@ -58,8 +58,11 @@ class CameraXManager(
 
     /** Declare and bind preview, capture and analysis use cases */
     fun bindCameraUseCases(binding: FragmentPixBinding) {
+        // Check if view is correctly attached to window, stop binding otherwise
+        val display = previewView.display ?: return
+
         // Get screen metrics used to setup camera for full screen resolution
-        val metrics = DisplayMetrics().also { previewView.display.getRealMetrics(it) }
+        val metrics = DisplayMetrics().also { display.getRealMetrics(it) }
         Log.d(TAG, "Screen metrics: ${metrics.widthPixels} x ${metrics.heightPixels}")
 
         val screenAspectRatio = when (options.ratio) {


### PR DESCRIPTION
Hi,

I've got a crash from the community
```
atal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.Display.getRealMetrics(android.util.DisplayMetrics)' on a null object reference
       at io.ak1.pix.helpers.CameraXManager.bindCameraUseCases(CameraXManager.java:62)
       at io.ak1.pix.helpers.CameraXManager.setUpCamera$lambda-0(CameraXManager.java:55)
       at io.ak1.pix.helpers.CameraXManager.lambda$saIgVXdcX8hBqOG6Idaj-FlC7bY(CameraXManager.java)
       at io.ak1.pix.helpers.-$$Lambda$CameraXManager$saIgVXdcX8hBqOG6Idaj-FlC7bY.run(-.java:6)
       at android.os.Handler.handleCallback(Handler.java:883)
       at android.os.Handler.dispatchMessage(Handler.java:100)
       at android.os.Looper.loop(Looper.java:237)
       at android.app.ActivityThread.main(ActivityThread.java:8167)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```

I try to fix it with the enclosing PR with this code:
```
val display = previewView.display ?: return
```


Also another idea was to do this code
```
val display = previewView.display?: throw IllegalStateException("View not attached to window.")
```
According to following code. But I do not see catching this exception thrown and guess that it would only move the crash to another place in the code.