### PR TITLE
Handle thrown illegalStateException when cams are unavailable in CameraXManager

### DIFF
--- a/pix/src/main/java/io/ak1/pix/PixFragment.kt
+++ b/pix/src/main/java/io/ak1/pix/PixFragment.kt
@@ -379,7 +379,7 @@ class PixFragment(private val resultCallback: ((PixEventCallback.Results) -> Uni
             PixBus.returnObjects(
                 event = PixEventCallback.Results(
                     ArrayList(),
-                    PixEventCallback.Status.SUCCESS
+                    PixEventCallback.Status.BACK_PRESSED
                 )
             )
         }

--- a/pix/src/main/java/io/ak1/pix/PixFragment.kt
+++ b/pix/src/main/java/io/ak1/pix/PixFragment.kt
@@ -370,9 +370,19 @@ class PixFragment(private val resultCallback: ((PixEventCallback.Results) -> Uni
 
 
     private fun CameraXManager.startCamera() {
-        setUpCamera(binding)
-        binding.gridLayout.controlsLayout.flashButton.show()
-        binding.setDrawableIconForFlash(options)
+        try {
+            setUpCamera(binding)
+            binding.gridLayout.controlsLayout.flashButton.show()
+            binding.setDrawableIconForFlash(options)
+        }catch (e:IllegalStateException){
+            resultCallback?.invoke(PixEventCallback.Results())
+            PixBus.returnObjects(
+                event = PixEventCallback.Results(
+                    ArrayList(),
+                    PixEventCallback.Status.SUCCESS
+                )
+            )
+        }
     }
 
     override fun onDestroy() {

--- a/pix/src/main/java/io/ak1/pix/helpers/CameraXManager.kt
+++ b/pix/src/main/java/io/ak1/pix/helpers/CameraXManager.kt
@@ -46,6 +46,7 @@ class CameraXManager(
 
 
     /** Initialize CameraX, and prepare to bind the camera use cases  */
+    @Throws(IllegalStateException::class)
     fun setUpCamera(binding: FragmentPixBinding) {
         val cameraProviderFuture = ProcessCameraProvider.getInstance(requireActivity)
         cameraProviderFuture.addListener({
@@ -57,6 +58,7 @@ class CameraXManager(
     }
 
     /** Declare and bind preview, capture and analysis use cases */
+    @Throws(IllegalStateException::class)
     fun bindCameraUseCases(binding: FragmentPixBinding) {
         // Check if view is correctly attached to window, stop binding otherwise
         val display = previewView.display ?: return


### PR DESCRIPTION
Hi,

when initialising camera hardware and binding, we check if camera are available and the throw exception if not, we can observe it in the following peace of code:

```
lensFacing = when {
            hasBackCamera() and !options.isFrontFacing -> CameraSelector.LENS_FACING_BACK
            hasFrontCamera() and options.isFrontFacing -> CameraSelector.LENS_FACING_FRONT
            else -> throw IllegalStateException("Back and front camera are unavailable")
        }
```

The main issue with this code is that this case actually happened on a moto g power (android 11) and the exception is thrown which is well anticipated code. But the exception is not handled and not delegated causing the application to crash. Here is what I propose in the PR:

1. Delegate exception to fragment

```
@Throws(IllegalStateException::class)
    fun bindCameraUseCases(binding: FragmentPixBinding) {
```

2. Handle exception in fragment by backpressing and return to the previous view

```
try {
            setUpCamera(binding)
            binding.gridLayout.controlsLayout.flashButton.show()
            binding.setDrawableIconForFlash(options)
        }catch (e:IllegalStateException){
            resultCallback?.invoke(PixEventCallback.Results())
            PixBus.returnObjects(
                event = PixEventCallback.Results(
                    ArrayList(),
                    PixEventCallback.Status.BACK_PRESSED
                )
            )
        }
```

Also work for another thrown in the same function.

Regards
73k05