### PR TITLE
[Enhancement] Add a flag to enable/disable gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ set configuration as
         spanCount = 4                                               //Number for columns in grid
         path = "Pix/Camera"                                         //Custom Path For media Storage
         isFrontFacing = false                                       //Front Facing camera on start
+        isGalleryEnabled = true                                     //Option to enable/disable gallery
         videoDurationLimitInSeconds = 10                            //Duration for video recording
         mode = Mode.All                                             //Option to select only pictures or videos or both
         flash = Flash.Auto                                          //Option to select flash type

--- a/pix/src/main/java/io/ak1/pix/PixFragment.kt
+++ b/pix/src/main/java/io/ak1/pix/PixFragment.kt
@@ -159,6 +159,7 @@ class PixFragment(private val resultCallback: ((PixEventCallback.Results) -> Uni
         setupFastScroller(context)
         observeSelectionList()
         retrieveMedia()
+        setGalleryViewVisibility()
         setBottomSheetBehavior()
         setupControls()
         backPressController()
@@ -181,8 +182,10 @@ class PixFragment(private val resultCallback: ((PixEventCallback.Results) -> Uni
             mainImageAdapter.addImageList(it.list)
             model.selectionList.value?.addAll(it.selection)
             model.selectionList.postValue(model.selectionList.value)
-            binding.gridLayout.arrowUp.apply {
-                if (mainImageAdapter.listSize != 0) show() else hide()
+            if (options.isGalleryEnabled) {
+                binding.gridLayout.arrowUp.apply {
+                    if (mainImageAdapter.listSize != 0) show() else hide()
+                }
             }
         }
         model.selectionList.observe(requireActivity()) {
@@ -285,6 +288,8 @@ class PixFragment(private val resultCallback: ((PixEventCallback.Results) -> Uni
     }
 
     private fun retrieveMedia() {
+        if (!options.isGalleryEnabled) return
+
         // options.preSelectedUrls.addAll(selectionList)
         if (options.preSelectedUrls.size > options.count) {
             val large = options.preSelectedUrls.size - 1
@@ -306,6 +311,11 @@ class PixFragment(private val resultCallback: ((PixEventCallback.Results) -> Uni
             model.retrieveImages(localResourceManager)
         }
 
+    }
+
+    private fun setGalleryViewVisibility() = binding.apply {
+        gridLayout.initialRecyclerviewContainer.visibility = if (options.isGalleryEnabled) View.VISIBLE
+        else View.GONE
     }
 
     private fun setupAdapters(context: FragmentActivity) {

--- a/pix/src/main/java/io/ak1/pix/helpers/ControlsHelper.kt
+++ b/pix/src/main/java/io/ak1/pix/helpers/ControlsHelper.kt
@@ -133,9 +133,11 @@ internal fun FragmentPixBinding.setupClickControls(
 
 
                     if (videoCounterProgress > options.videoOptions.videoDurationLimitInSeconds) {
-                        gridLayout.initialRecyclerviewContainer.apply {
-                            alpha = 1f
-                            translationY = 0f
+                        if (options.isGalleryEnabled) {
+                            gridLayout.initialRecyclerviewContainer.apply {
+                                alpha = 1f
+                                translationY = 0f
+                            }
                         }
                         callback(5, Uri.EMPTY)
                         isRecording = false
@@ -153,8 +155,10 @@ internal fun FragmentPixBinding.setupClickControls(
             val maxVideoDuration = options.videoOptions.videoDurationLimitInSeconds
             videoCounterLayout.videoPbr.max = maxVideoDuration / 1000
             videoCounterLayout.videoPbr.invalidate()
-            gridLayout.initialRecyclerviewContainer.animate().translationY(500f).alpha(0f)
-                .setDuration(200).start()
+            if (options.isGalleryEnabled) {
+                gridLayout.initialRecyclerviewContainer.animate().translationY(500f).alpha(0f)
+                    .setDuration(200).start()
+            }
             cameraXManager?.takeVideo { uri, exc ->
                 if (exc == null) {
                     callback(3, uri)
@@ -187,9 +191,11 @@ internal fun FragmentPixBinding.setupClickControls(
                 root.requestDisallowInterceptTouchEvent(true)
             }
             if ((event.action == MotionEvent.ACTION_UP || event.action == MotionEvent.ACTION_CANCEL) && isRecording) {
-                gridLayout.initialRecyclerviewContainer.apply {
-                    alpha = 1f
-                    translationY = 0f
+                if (options.isGalleryEnabled) {
+                    gridLayout.initialRecyclerviewContainer.apply {
+                        alpha = 1f
+                        translationY = 0f
+                    }
                 }
                 callback(5, Uri.EMPTY)
                 isRecording = false

--- a/pix/src/main/java/io/ak1/pix/models/Models.kt
+++ b/pix/src/main/java/io/ak1/pix/models/Models.kt
@@ -35,6 +35,7 @@ class Options : Parcelable {
     var spanCount = 4
     var path = "Pix/Camera"
     var isFrontFacing = false
+    var isGalleryEnabled = true
     var mode = Mode.All
     var flash = Flash.Auto
     var preSelectedUrls = ArrayList<Uri>()


### PR DESCRIPTION
One of my business use cases while using this library as the primary image picker/camera was to ensure users can only click a photo and not select it from the gallery.

I have introduced a flag isGalleryEnabled in Options class and disabled/enabled the operations being performed on this view accordingly.