### PR TITLE
Add variables to default constructor of model to be parcelable

### DIFF
--- a/pix/src/main/java/io/ak1/pix/models/Models.kt
+++ b/pix/src/main/java/io/ak1/pix/models/Models.kt
@@ -1,18 +1,15 @@
 package io.ak1.pix.models
 
-import android.annotation.SuppressLint
 import android.net.Uri
 import android.os.Parcelable
 import kotlinx.parcelize.IgnoredOnParcel
-
 import kotlinx.parcelize.Parcelize
-import java.util.*
 
 /**
  * Created By Akshay Sharma on 17,June,2021
  * https://ak1.io
  */
-@SuppressLint("ParcelCreator")
+
 @Parcelize
 data class Img(
     var headerDate: String = "",
@@ -27,32 +24,32 @@ data class Img(
     var position = 0
 }
 
-@SuppressLint("ParcelCreator")
 @Parcelize
-class Options : Parcelable {
-    var ratio = Ratio.RATIO_AUTO
-    var count = 1
-    var spanCount = 4
-    var path = "Pix/Camera"
-    var isFrontFacing = false
-    var mode = Mode.All
-    var flash = Flash.Auto
-    var preSelectedUrls = ArrayList<Uri>()
-    var videoOptions : VideoOptions = VideoOptions()
-}
+class Options(
+    var ratio: Ratio = Ratio.RATIO_AUTO,
+    var count: Int = 1,
+    var spanCount: Int = 4,
+    var path: String = "Pix/Camera",
+    var isFrontFacing: Boolean = false,
+    var mode: Mode = Mode.All,
+    var flash: Flash = Flash.Auto,
+    var preSelectedUrls: ArrayList<Uri> = ArrayList(),
+    var videoOptions: VideoOptions = VideoOptions()
+) : Parcelable
 
 @Parcelize
 enum class Mode : Parcelable {
     All, Picture, Video
 }
-@SuppressLint("ParcelCreator")
+
+
 @Parcelize
-class VideoOptions : Parcelable {
-    var videoBitrate : Int? = null
-    var audioBitrate : Int? = null
-    var videoFrameRate : Int? = null
-    var videoDurationLimitInSeconds = 10
-}
+class VideoOptions(
+    var videoBitrate: Int? = null,
+    var audioBitrate: Int? = null,
+    var videoFrameRate: Int? = null,
+    var videoDurationLimitInSeconds: Int = 10
+) : Parcelable
 
 @Parcelize
 enum class Flash : Parcelable {


### PR DESCRIPTION
Currently, the model classes do not generate correct Parcelable code since the variables have to be defined in the primary constructor for classes for them to be parcelable.