### PR TITLE
Allow to user can select the 5 images without opening the setting Activity

### DIFF
--- a/app/src/main/java/io/ak1/pixsample/MainActivity.kt
+++ b/app/src/main/java/io/ak1/pixsample/MainActivity.kt
@@ -68,13 +68,16 @@ class MainActivity : AppCompatActivity() {
                     30
                 }
             }
+            /**
+             * allow to user can select 5 image first time.
+             */
             count = try {
-                sp.getString("count", "1")?.toInt() ?: 1
+                sp.getString("count", "5")?.toInt() ?: 5
             } catch (e: Exception) {
                 sp.apply {
-                    edit().putString("count", "1").commit()
+                    edit().putString("count", "5").commit()
                 }
-                1
+                5
             }
             spanCount = sp.getString("spanCount", "4")?.toInt() ?: 4
         }


### PR DESCRIPTION
[Issue Link](https://github.com/akshay2211/PixImagePicker/issues/282)

## Problem

User was not able to select 5 images without opening the setting activity in setting we putting the default value in prefs. 

## Solution

I just set the value of count is 5 initially . 

if anyone have good solution please add your views 